### PR TITLE
[UD-86] Remove Gem hunter match reference from RadioUI.cs

### DIFF
--- a/src/Assets.csproj
+++ b/src/Assets.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Assets\Scripts\PlaylistUtils\PlaylistController.cs" />
     <Compile Include="Assets\Scripts\PurchaseConfirmationDialog.cs" />
     <Compile Include="Assets\Scripts\SubscriptionsAndBundles\RadioBundlesHandler.cs" />
+    <Compile Include="Assets\Scripts\PlaylistUtils\PlaylistService.cs" />
     <Compile Include="Assets\Scripts\ConfigurationLoader.cs" />
     <Compile Include="Assets\Scripts\GroupSession\DTO\Responses\ActiveGroupSessionDTO.cs" />
     <Compile Include="Assets\Scripts\SubscriptionsAndBundles\SubscriptionTile.cs" />
@@ -127,6 +128,7 @@
     <Compile Include="Assets\Scripts\SubscriptionsAndBundles\RadioSubscriptionHandler.cs" />
     <Compile Include="Assets\GemHunterMatch\Scripts\LevelList.cs" />
     <Compile Include="Assets\Scripts\SubscriptionInfoDialog.cs" />
+    <Compile Include="Assets\Scripts\PlaylistUtils\IPlaylistProvider.cs" />
     <Compile Include="Assets\GemHunterMatch\Scripts\Match.cs" />
     <Compile Include="Assets\GemHunterMatch\Scripts\LightManager.cs" />
     <Compile Include="Assets\WebGLSupport\WebGLInput\Detail\RebuildChecker.cs" />
@@ -149,8 +151,6 @@
     <None Include="Assets\TextMesh Pro\Shaders\TMP_SDF SSD.shader" />
     <None Include="Assets\UI\UI Toolkit\StripeRadio.uxml" />
     <None Include="Assets\UI\UI Toolkit\StripeRadioTemplate.uxml" />
-    <None Include="Assets\Packages\WebSocketSharp-netstandard.1.0.1\lib\netstandard2.0\websocket-sharp.xml" />
-    <None Include="Assets\Packages\WebSocketSharp-netstandard.1.0.1\lib\netstandard2.0\websocket-sharp.dll" />
     <None Include="Assets\TextMesh Pro\Shaders\TMP_SDF-Surface-Mobile.shader" />
     <None Include="Assets\UI\UI Toolkit\RadioStripe.uss" />
     <None Include="Assets\GemHunterMatch\UI\GoalGemTemplate.uxml" />

--- a/src/Assets/GemHunterMatch/Scripts/GameManager.cs
+++ b/src/Assets/GemHunterMatch/Scripts/GameManager.cs
@@ -1,3 +1,4 @@
+using Assets.Scripts.PlaylistUtils;
 using Styngr.Model.Radio;
 using System;
 using System.Collections;
@@ -14,12 +15,12 @@ namespace Match3
     /// so we can press play from any point of the game without having to add it to every scene and test if it already exist
     /// </summary>
     [DefaultExecutionOrder(-9999)]
-    public class GameManager : MonoBehaviour
+    public class GameManager : MonoBehaviour, IPlaylistProvider
     {
         //This is set to true when the manager is deleted. This is useful as the manager can be deleted before other
         //objects 
         private static bool s_IsShuttingDown = false;
-        private static Playlist selectedPlaylist = null;
+        private static Playlist selectedPlaylist;
 
         public static GameManager Instance
         {
@@ -46,7 +47,7 @@ namespace Match3
             return s_IsShuttingDown;
         }
 
-        public static Playlist GetSelectedPlaylist()
+        public Playlist GetSelectedPlaylist()
         {
             return selectedPlaylist;
         }
@@ -139,6 +140,8 @@ namespace Match3
                 m_LoseEffect = Instantiate(Settings.VisualSettings.LoseEffect, transform);
 
                 LoadSoundData();
+
+                PlaylistService.RegisterProvider(this);
             }
         }
 

--- a/src/Assets/Scripts/PlaylistUtils/IPlaylistProvider.cs
+++ b/src/Assets/Scripts/PlaylistUtils/IPlaylistProvider.cs
@@ -1,0 +1,11 @@
+using Styngr.Model.Radio;
+
+
+namespace Assets.Scripts.PlaylistUtils
+{
+    public interface IPlaylistProvider
+    {
+        Playlist GetSelectedPlaylist();
+    }
+}
+

--- a/src/Assets/Scripts/PlaylistUtils/IPlaylistProvider.cs.meta
+++ b/src/Assets/Scripts/PlaylistUtils/IPlaylistProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfa1952fec27615458783c54f8f9b971
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Assets/Scripts/PlaylistUtils/PlaylistController.cs
+++ b/src/Assets/Scripts/PlaylistUtils/PlaylistController.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using UnityEngine;
 using static Packages.StyngrSDK.Runtime.Scripts.Radio.JWT_Token;
 
+
 namespace Assets.Scripts.PlaylistUtils
 {
     /// <summary>

--- a/src/Assets/Scripts/PlaylistUtils/PlaylistService.cs
+++ b/src/Assets/Scripts/PlaylistUtils/PlaylistService.cs
@@ -1,0 +1,41 @@
+using Styngr.Model.Radio;
+using UnityEngine;
+
+
+namespace Assets.Scripts.PlaylistUtils
+{
+    public static class PlaylistService
+    {
+        private static IPlaylistProvider provider;
+
+        /// <summary>
+        /// Current playlist
+        /// </summary>
+        public static IPlaylistProvider Current => provider;
+
+        /// <summary>
+        /// Registers playlist provider
+        /// </summary>
+        /// <param name="_provider"></param>
+        public static void RegisterProvider(IPlaylistProvider _provider)
+        {
+            provider = _provider;
+            Debug.Log($"Playlist provider registered: {provider.GetType().Name}");
+        }
+
+        /// <summary>
+        /// Get current playlist
+        /// </summary>
+        /// <returns></returns>
+        public static Playlist GetSelectedPlaylist()
+        {
+            if (provider == null)
+            {
+                Debug.LogError("No playlist provider registered.");
+                return null;
+            }
+
+            return provider.GetSelectedPlaylist();
+        }
+    }
+}

--- a/src/Assets/Scripts/PlaylistUtils/PlaylistService.cs.meta
+++ b/src/Assets/Scripts/PlaylistUtils/PlaylistService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 246a5bc9cd152c94090bebb94da8d537
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Assets/Scripts/UIRadio.cs
+++ b/src/Assets/Scripts/UIRadio.cs
@@ -565,7 +565,7 @@ namespace Assets.Scripts
 
             radioTypeSelector.SetActive(false);
 
-            var selectedPlaylist = Match3.GameManager.GetSelectedPlaylist();
+            var selectedPlaylist = PlaylistService.GetSelectedPlaylist();
 
             if (selectedPlaylist == null)
             {

--- a/src/Assets/Scripts/UIRadioHandler.cs
+++ b/src/Assets/Scripts/UIRadioHandler.cs
@@ -8,7 +8,7 @@ using System.Collections.Concurrent;
 using UnityEngine;
 using UnityEngine.UIElements;
 using Packages.StyngrSDK.Runtime.Scripts.Store.Utility.Enums;
-using Packages.StyngrSDK.Runtime.Scripts.Store;
+using Assets.Scripts.PlaylistUtils;
 
 
 
@@ -308,8 +308,8 @@ namespace Assets.Scripts
             playButton.SetEnabled(value);
             muteToggle.SetEnabled(value);
             volumeSlider.SetEnabled(value);
-     
-            likeButton.SetEnabled(value);         
+
+            likeButton.SetEnabled(value);
         }
 
         private void InitUIElements()
@@ -360,7 +360,7 @@ namespace Assets.Scripts
                 subscriptionManager.CheckSubscriptionAndSetActivity();
             }
 
-            var selectedPlaylist = Match3.GameManager.GetSelectedPlaylist();
+            var selectedPlaylist = PlaylistService.GetSelectedPlaylist();
 
             if (selectedPlaylist == null)
             {


### PR DESCRIPTION
- Decouple `Playlist` access using interface and service locator pattern
- Introduce `IPlaylistProvider` interface for abstraction
- Made `GameManager` implement `IPlaylistProvider` and register provider on `Awake`
- Added `PlaylistService` to globally access selected `Playlist`